### PR TITLE
fix: current prayer time 0:0 if next prayer fajr

### DIFF
--- a/src/salah/times.rs
+++ b/src/salah/times.rs
@@ -272,7 +272,14 @@ impl PrayerTimes {
     /// Remaining time to next prayer
     pub fn time_remaining(&self) -> Result<(u32, u32), crate::Error> {
         let next_prayer_time = self.time(self.next()?);
-        let now_to_next = next_prayer_time - time::now();
+        let now_to_next;
+        // Check if the next prayer is Fajr (Because Fajr time is less than current time)
+        if next_prayer_time < time::now() {
+            now_to_next = (time::one_sec_before_midnight() - time::now())
+                + (next_prayer_time - time::one_sec_after_midnight());
+        } else {
+            now_to_next = next_prayer_time - time::now();
+        }
         let now_to_next = now_to_next.num_seconds() as f64;
 
         let whole: f64 = now_to_next / 60.0 / 60.0;

--- a/src/salah/times.rs
+++ b/src/salah/times.rs
@@ -275,8 +275,16 @@ impl PrayerTimes {
         let now_to_next;
         // Check if the next prayer is Fajr (Because Fajr time is less than current time)
         if next_prayer_time < time::now() {
-            now_to_next = (time::one_sec_before_midnight() - time::now())
-                + (next_prayer_time - time::one_sec_after_midnight());
+            let time_before_midnight = match time::one_sec_before_midnight() {
+                Some(before_midnight) => before_midnight - time::now(),
+                None => Duration::zero(),
+            };
+            let time_after_midnight = match time::midnight() {
+                Some(after_midnight) => next_prayer_time - after_midnight,
+                None => Duration::zero(),
+            };
+
+            now_to_next = time_before_midnight + time_after_midnight;
         } else {
             now_to_next = next_prayer_time - time::now();
         }

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,9 +1,19 @@
-use chrono::{Local, NaiveDate};
+use chrono::{Local, NaiveDate, NaiveTime};
 
 use crate::{Date, DateTime};
 
 pub fn now() -> DateTime {
     Local::now().naive_local()
+}
+
+pub fn one_sec_before_midnight() -> DateTime {
+    let midnight = NaiveTime::from_hms_opt(23, 59, 59);
+    Local::now().date_naive().and_time(midnight.unwrap())
+}
+
+pub fn one_sec_after_midnight() -> DateTime {
+    let midnight = NaiveTime::from_hms_opt(0, 0, 01);
+    Local::now().date_naive().and_time(midnight.unwrap())
 }
 
 pub fn today() -> Date {

--- a/src/time.rs
+++ b/src/time.rs
@@ -6,14 +6,18 @@ pub fn now() -> DateTime {
     Local::now().naive_local()
 }
 
-pub fn one_sec_before_midnight() -> DateTime {
-    let midnight = NaiveTime::from_hms_opt(23, 59, 59);
-    Local::now().date_naive().and_time(midnight.unwrap())
+pub fn one_sec_before_midnight() -> Option<DateTime> {
+    let midnight = NaiveTime::from_hms_opt(23, 59, 59)?;
+    let date = Local::now().date_naive();
+
+    Some(date.and_time(midnight))
 }
 
-pub fn one_sec_after_midnight() -> DateTime {
-    let midnight = NaiveTime::from_hms_opt(0, 0, 01);
-    Local::now().date_naive().and_time(midnight.unwrap())
+pub fn midnight() -> Option<DateTime> {
+    let midnight = NaiveTime::from_hms_opt(0, 0, 00)?;
+    let date = Local::now().date_naive();
+
+    Some(date.and_time(midnight))
 }
 
 pub fn today() -> Date {


### PR DESCRIPTION
Bug: remaining time before next prayer is showing 0:0 if current prayer is isya

The usual next_prayer - current_time not gonna work
Because fajr time value is less than current time (after isya)